### PR TITLE
No fetching of empty key sets

### DIFF
--- a/diode-data/shared/src/main/scala/diode/data/AsyncAction.scala
+++ b/diode-data/shared/src/main/scala/diode/data/AsyncAction.scala
@@ -60,7 +60,7 @@ object AsyncAction {
 
   def mapHandler[K, V, A <: Traversable[(K, Pot[V])], M, P <: AsyncAction[A, P]](keys: Set[K])
     (implicit ec: ExecutionContext) = {
-    require(keys.nonEmpty)
+    require(keys.nonEmpty, "AsyncAction:mapHandler - The set of keys to update can't be empty")
     (action: AsyncAction[A, P], handler: ActionHandler[M, PotMap[K, V]], updateEffect: Effect) => {
       import PotState._
       import handler._
@@ -92,7 +92,7 @@ object AsyncAction {
 
   def vectorHandler[V, A <: Traversable[(Int, Pot[V])], M, P <: AsyncAction[A, P]](indices: Set[Int])
     (implicit ec: ExecutionContext) = {
-    require(indices.nonEmpty)
+    require(indices.nonEmpty, "AsyncAction:vectorHandler - The set of indices to update can't be empty")
     (action: AsyncAction[A, P], handler: ActionHandler[M, PotVector[V]], updateEffect: Effect) => {
       import PotState._
       import handler._
@@ -131,7 +131,7 @@ object AsyncActionRetriable {
 
   def mapHandler[K, V, A <: Traversable[(K, Pot[V])], M, P <: AsyncActionRetriable[A, P]](keys: Set[K])
     (implicit ec: ExecutionContext) = {
-    require(keys.nonEmpty)
+    require(keys.nonEmpty, "AsyncActionRetriable:mapHandler - The set of keys to update can't be empty")
     (action: AsyncActionRetriable[A, P], handler: ActionHandler[M, PotMap[K, V]], updateEffect: RetryPolicy => Effect) => {
       import PotState._
       import handler._
@@ -167,7 +167,7 @@ object AsyncActionRetriable {
 
   def vectorHandler[V, A <: Traversable[(Int, Pot[V])], M, P <: AsyncActionRetriable[A, P]](indices: Set[Int])
     (implicit ec: ExecutionContext) = {
-    require(indices.nonEmpty)
+    require(indices.nonEmpty, "AsyncActionRetriable:vectorHandler - The set of indices to update can't be empty")
     (action: AsyncActionRetriable[A, P], handler: ActionHandler[M, PotVector[V]], updateEffect: RetryPolicy => Effect) => {
       import PotState._
       import handler._

--- a/diode-data/shared/src/main/scala/diode/data/PotMap.scala
+++ b/diode-data/shared/src/main/scala/diode/data/PotMap.scala
@@ -77,7 +77,11 @@ class PotMap[K, V](
           (key, Pending().asInstanceOf[Pot[V]])
       }
     }(collection.breakOut)
-    fetcher.fetch(toFetch)
+
+    if(toFetch.nonEmpty) {
+      fetcher.fetch(toFetch)
+    }
+
     values
   }
 


### PR DESCRIPTION
```PotMap``` will do a fetch even if it is not needed (empty toFetch). Together with the default mapHandler it blows.