### PR TITLE
Allow chaining of ReactPot render functions

### DIFF
--- a/diode-react/src/main/scala/diode/react/ReactPot.scala
+++ b/diode-react/src/main/scala/diode/react/ReactPot.scala
@@ -9,7 +9,7 @@ object ReactPot {
 
   implicit def potRenderer[A](pot: Pot[A]) : potWithReact[A] = potWithReact(pot, Nil)
 
-  implicit def toReact(p : potWithReact[_]) : ReactNode = p.nodes
+  implicit def toReact(p : potWithReact[_]) : ReactNode = p.nodes.reverse
 
 
   case class potWithReact[A](pot: Pot[A], nodes: List[ReactNode]) {

--- a/diode-react/src/main/scala/diode/react/ReactPot.scala
+++ b/diode-react/src/main/scala/diode/react/ReactPot.scala
@@ -1,20 +1,26 @@
 package diode.react
 
 import diode.data.{PendingBase, Pot}
-import diode.util._
 import japgolly.scalajs.react.ReactNode
 
 object ReactPot {
 
-  implicit class potWithReact[A](val pot: Pot[A]) extends AnyVal {
+  import scala.language.implicitConversions
+
+  implicit def potRenderer[A](pot: Pot[A]) : potWithReact[A] = potWithReact(pot, Nil)
+
+  implicit def toReact(p : potWithReact[_]) : ReactNode = p.nodes
+
+
+  case class potWithReact[A](pot: Pot[A], nodes: List[ReactNode]) {
     /**
       * Render non-empty (ready or stale) content
  *
       * @param f Transforms Pot value into a ReactNode
       * @return
       */
-    def render(f: A => ReactNode): ReactNode =
-      if (pot.nonEmpty) f(pot.get) else null
+    def render(f: A => ReactNode): potWithReact[A] =
+      if (pot.nonEmpty) copy(nodes = f(pot.get) :: nodes) else this
 
     /**
       * Render content in Ready state, not including stale states
@@ -22,8 +28,8 @@ object ReactPot {
       * @param f Transforms Pot value into a ReactNode
       * @return
       */
-    def renderReady(f: A => ReactNode): ReactNode =
-      if (pot.isReady) f(pot.get) else null
+    def renderReady(f: A => ReactNode): potWithReact[A] =
+      if (pot.isReady) copy(nodes = f(pot.get) :: nodes) else this
 
     /**
       * Render when Pot is pending
@@ -31,8 +37,8 @@ object ReactPot {
       * @param f Transforms duration time into a ReactNode
       * @return
       */
-    def renderPending(f: Int => ReactNode): ReactNode =
-      if (pot.isPending) f(pot.asInstanceOf[PendingBase].duration()) else null
+    def renderPending(f: Int => ReactNode): potWithReact[A] =
+      if (pot.isPending) copy(nodes = f(pot.asInstanceOf[PendingBase].duration()) :: nodes) else this
 
     /**
       * Render when Pot is pending with a filter on duration
@@ -41,10 +47,10 @@ object ReactPot {
       * @param f Transforms duration time into a ReactNode
       * @return
       */
-    def renderPending(b: Int => Boolean, f: Int => ReactNode): ReactNode = {
+    def renderPending(b: Int => Boolean, f: Int => ReactNode): potWithReact[A] = {
       if (pot.isPending) {
         val duration = pot.asInstanceOf[PendingBase].duration()
-        if (b(duration)) f(duration) else null
+        if (b(duration)) copy(nodes = f(duration) :: nodes) else this
       } else null
     }
 
@@ -54,8 +60,8 @@ object ReactPot {
       * @param f Transforms an exception into a ReactNode
       * @return
       */
-    def renderFailed(f: Throwable => ReactNode): ReactNode =
-      pot.exceptionOption.map(f).orNull
+    def renderFailed(f: Throwable => ReactNode): potWithReact[A] =
+      if (pot.isFailed) copy(nodes = f(pot.exceptionOption.get) :: nodes) else this
 
     /**
       * Render stale content (`PendingStale` or `FailedStale`)
@@ -63,8 +69,8 @@ object ReactPot {
       * @param f Transforms Pot value into a ReactNode
       * @return
       */
-    def renderStale(f: A => ReactNode): ReactNode =
-      if (pot.isStale) f(pot.get) else null
+    def renderStale(f: A => ReactNode): potWithReact[A] =
+      if (pot.isStale) copy(nodes = f(pot.get) :: nodes) else this
 
     /**
       * Render when Pot is empty
@@ -72,8 +78,8 @@ object ReactPot {
       * @param f Returns a ReactNode
       * @return
       */
-    def renderEmpty(f: => ReactNode): ReactNode =
-      if (pot.isEmpty) f else null
+    def renderEmpty(f: => ReactNode): potWithReact[A] =
+      if (pot.isEmpty) copy(nodes = f :: nodes) else this
   }
 
 }


### PR DESCRIPTION
This a suggestion for changing the potWithReact class to allow chaining of .render functions like so:

```scala
proxy()
  .render(m => ...)
  .renderPending(_ > 500, _ => "Loading...")
  .renderFailed(ex => "Error loading")
```
