### PR TITLE
Fix: folded handlers ignore intermediate changes in model

### DIFF
--- a/diode-core/shared/src/main/scala/diode/ModelRW.scala
+++ b/diode-core/shared/src/main/scala/diode/ModelRW.scala
@@ -286,7 +286,7 @@ class RootModelRW[M <: AnyRef](get: => M) extends RootModelR(get) with BaseModel
 
   // override for root because it's a simpler case
   override def zoomRW[T](get: M => T)(set: (M, T) => M)(implicit feq: FastEq[_ >: T]) =
-    new ZoomModelRW[M, T](this, get, (s, u) => set(value, u))
+    new ZoomModelRW[M, T](this, get, set)
 }
 
 /**

--- a/diode-core/shared/src/test/scala/diode/ModelRWTests.scala
+++ b/diode-core/shared/src/test/scala/diode/ModelRWTests.scala
@@ -197,5 +197,13 @@ object ModelRWTests extends TestSuite {
       val m2 = crw.updated(Some(A(42, "new")))
       assert(m2.c.flatMap(_.o.map(_.s)).contains("new"))
     }
+    'zoomRW - {
+      val m = A(1, "old")
+      val mrw = new RootModelRW(m)
+      val zoomRW = mrw.zoomRW(_.i)((m, v) ⇒ m.copy(i = v))
+      val r = zoomRW.updatedWith(m.copy(s = "new"), 2)
+      assert(r.i == 2)
+      assert(r.s == "new")
+    }
   }
 }


### PR DESCRIPTION
`RootModelRW.zoomRW` ignores model provided to `set` function it cause that `ZoomModelRW.updatedWith` doesn't update model from parameter only the one from `RootModelRW` however get operates on different model.

I tried to implement handlers that modify different parts of the model and fold them. Unfortunately, current implementation caused that only changes introduced by the last handler were present.

```scala
case class Model(a: String, b: String)

object TestCircuit extends Circuit[Model] {

  def initialModel = Model("", "")

  val aHandler = new ActionHandler(zoomRW(_.a)((m, v) ⇒ m.copy(a = v))) {
    def handle = {
      case a =>
        updated(a.toString)
    }
  }
  val bHandler = new ActionHandler(zoomRW(_.b)((m, v) ⇒ m.copy(b = v))) {
    def handle = {
      case a =>
        updated(a.toString)
    }
  }


  def actionHandler = foldHandlers(
    aHandler, bHandler
  )
}
```