### PR TITLE
Adds a bit of typesafety via trait Action fixes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Since having a static counter is not very interesting, we'll want to have some w
 the application model happen through _actions_. Let's define a couple of useful actions:
 
 ```scala
-case class Increase(amount: Int)
-case class Decrease(amount: Int)
-case object Reset
+case class Increase(amount: Int) extends Action
+case class Decrease(amount: Int) extends Action
+case object Reset extends Action
 ```
 
 Actions in Diode can be anything (that extends `AnyRef`), but typically case classes work best due to their pattern

--- a/diode-core/jvm/src/test/scala/diode/CircuitJVMTests.scala
+++ b/diode-core/jvm/src/test/scala/diode/CircuitJVMTests.scala
@@ -11,13 +11,13 @@ object CircuitJVMTests extends TestSuite {
   case class Model(list: Vector[Int])
 
   // actions
-  case class Append(i: Int)
+  case class Append(i: Int) extends Action
 
-  case class Prepend(i: Int)
+  case class Prepend(i: Int) extends Action
 
-  case class Filter(f: Int => Boolean)
+  case class Filter(f: Int => Boolean) extends Action
 
-  case class RunEffects[A <: AnyRef](effects: Seq[Effect], parallel: Boolean = false)
+  case class RunEffects[A <: AnyRef](effects: Seq[Effect], parallel: Boolean = false) extends Action
 
   class TestCircuit(implicit ec: ExecutionContext) extends Circuit[Model] {
     import diode.ActionResult._
@@ -93,14 +93,14 @@ object CircuitJVMTests extends TestSuite {
     'SequenceActions - {
       val c = circuit
       val actions = for (i <- 0 until 1000) yield Append(i)
-      c.dispatch(actions)
+      c.dispatch(ActionSeq(actions))
       assert(c.model.list.size == 1000)
       assert(c.model.list == Vector.range(0, 1000))
     }
     'SequenceActionEffects - {
       val c = circuit
       val actions = for (i <- 0 until 1000) yield RunEffects(Seq(() => Future(Append(i))))
-      c.dispatch(actions)
+      c.dispatch(ActionSeq(actions))
       // wait for futures to complete
       Thread.sleep(300)
       assert(c.model.list.size == 1000)

--- a/diode-core/shared/src/main/scala/diode/ActionHandler.scala
+++ b/diode-core/shared/src/main/scala/diode/ActionHandler.scala
@@ -22,7 +22,7 @@ abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
   /**
     * Handles the incoming action by updating current model and calling the real `handle` function
     */
-  def handleAction(model: M, action: AnyRef): Option[ActionResult[M]] = {
+  def handleAction(model: M, action: Action): Option[ActionResult[M]] = {
     currentModel = model
     liftedHandler(action)
   }
@@ -30,7 +30,7 @@ abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
   /**
     * Override this function to handle dispatched actions.
     */
-  protected def handle: PartialFunction[AnyRef, ActionResult[M]]
+  protected def handle: PartialFunction[Action, ActionResult[M]]
 
   /**
     * Helper function that returns the current value from the model.
@@ -100,11 +100,11 @@ abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
     * @param delay How much to delay the effect.
     * @param f     Result of the effect
     */
-  def runAfter[A <: AnyRef](delay: FiniteDuration)(f: => A)(implicit runner: RunAfter, ec: ExecutionContext): Effect =
+  def runAfter[A <: Action](delay: FiniteDuration)(f: => A)(implicit runner: RunAfter, ec: ExecutionContext): Effect =
     Effect(runner.runAfter(delay)(f))
 }
 
 object ActionHandler {
-  implicit def extractHandler[M <: AnyRef](actionHandler: ActionHandler[M, _]): (M, AnyRef) => Option[ActionResult[M]] =
+  implicit def extractHandler[M <: AnyRef](actionHandler: ActionHandler[M, _]): (M, Action) => Option[ActionResult[M]] =
     actionHandler.handleAction
 }

--- a/diode-core/shared/src/test/scala/diode/util/RetryTests.scala
+++ b/diode-core/shared/src/test/scala/diode/util/RetryTests.scala
@@ -9,10 +9,11 @@ import scala.concurrent.duration._
 import diode.Implicits.runAfterImpl
 
 object RetryTests extends TestSuite {
+  case object TheAnswer extends diode.Action
   def tests = TestSuite {
     'Immediate - {
       val policy = Retry.Immediate(3)
-      val effect = (retryPolicy: RetryPolicy) => Effect(Future("42"))
+      val effect = (retryPolicy: RetryPolicy) => Effect(Future(TheAnswer))
       val r = policy.retry(new Exception, effect)
       assertMatch(r) {
         case Right((nextPolicy, newEffect)) =>
@@ -22,7 +23,7 @@ object RetryTests extends TestSuite {
     }
     'Backoff - {
       val policy = Retry.Backoff(3, 200.millis)
-      val effect = (retryPolicy: RetryPolicy) => Effect(Future("42"))
+      val effect = (retryPolicy: RetryPolicy) => Effect(Future(TheAnswer))
       val r = policy.retry(new Exception, effect)
       assert(r.isRight)
       val now = System.currentTimeMillis()

--- a/diode-data/shared/src/main/scala/diode/data/AsyncAction.scala
+++ b/diode-data/shared/src/main/scala/diode/data/AsyncAction.scala
@@ -1,7 +1,7 @@
 package diode.data
 
 import diode.util.RetryPolicy
-import diode.{ActionHandler, ActionResult, Effect}
+import diode.{ActionHandler, ActionResult, Effect, Action}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success, Try}
   * @tparam A Type of action result
   * @tparam P Type of the actual action class
   */
-trait AsyncAction[A, P <: AsyncAction[A, P]] {
+trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
   def state: PotState
 
   def result: Try[A]

--- a/diode-data/shared/src/test/scala/diode/data/PotActionTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/PotActionTests.scala
@@ -89,7 +89,7 @@ object PotActionTests extends TestSuite {
         val eff = ta.effect(Future {completed = !completed; 42})(_.toString)
 
         eff.toFuture.map { action =>
-          assert(action.potResult == Ready("42"))
+          assert(action.head.potResult == Ready("42"))
           assert(completed == true)
         }
       }
@@ -98,7 +98,7 @@ object PotActionTests extends TestSuite {
         val eff = ta.effect(Future {if (true) throw new Exception("Oh no!") else 42})(_.toString, ex => new Exception(ex.getMessage * 2))
 
         eff.toFuture.map { action =>
-          assert(action.potResult.exceptionOption.exists(_.getMessage == "Oh no!Oh no!"))
+          assert(action.head.potResult.exceptionOption.exists(_.getMessage == "Oh no!Oh no!"))
         }
       }
     }
@@ -119,7 +119,7 @@ object PotActionTests extends TestSuite {
             ???
         }
         nextAction.map {
-          case TestAction(value) if value.isReady =>
+          case List(TestAction(value)) if value.isReady =>
             assert(value.get == "42")
           case _ => assert(false)
         }
@@ -135,7 +135,7 @@ object PotActionTests extends TestSuite {
             ???
         }
         nextAction.map {
-          case TestAction(value) if value.isFailed =>
+          case List(TestAction(value)) if value.isFailed =>
             assert(value.exceptionOption.get.isInstanceOf[TimeoutException])
           case _ => assert(false)
         }
@@ -161,7 +161,7 @@ object PotActionTests extends TestSuite {
             ???
         }
         nextAction.map {
-          case TestActionRP(value, _) if value.isFailed =>
+          case List(TestActionRP(value, _)) if value.isFailed =>
             assert(value.exceptionOption.get.isInstanceOf[TimeoutException])
           case _ => assert(false)
         }
@@ -182,7 +182,7 @@ object PotActionTests extends TestSuite {
             ???
         }
         nextAction.map {
-          case TestCollAction(state, value) if state == PotState.PotReady =>
+          case List(TestCollAction(state, value)) if state == PotState.PotReady =>
             assert(value.get == Set(("A", Ready("42"))))
           case _ => assert(false)
         }

--- a/diode-devtools/shared/src/main/scala/diode/dev/PersistState.scala
+++ b/diode-devtools/shared/src/main/scala/diode/dev/PersistState.scala
@@ -25,9 +25,9 @@ abstract class PersistState[M <: AnyRef, P] extends ActionProcessor[M] {
   def load(id: String): Future[P]
 
   // internal action dispatched once loading is completed
-  private final case class Loaded(newModel: M)
+  private final case class Loaded(newModel: M) extends Action
 
-  override def process(dispatch: Dispatcher, action: AnyRef, next: (AnyRef) => ActionResult[M], currentModel: M) = {
+  override def process(dispatch: Dispatcher, action: Action, next: Action => ActionResult[M], currentModel: M) = {
     action match {
       case Save(id) =>
         // pickle and save
@@ -49,8 +49,8 @@ abstract class PersistState[M <: AnyRef, P] extends ActionProcessor[M] {
 object PersistState {
 
   // define external actions
-  final case class Save(id: String)
+  final case class Save(id: String) extends Action
 
-  final case class Load(id: String)
+  final case class Load(id: String) extends Action
 
 }

--- a/diode-react/src/main/scala/diode/react/ReactConnector.scala
+++ b/diode-react/src/main/scala/diode/react/ReactConnector.scala
@@ -10,9 +10,10 @@ import scala.scalajs.js
   * Wraps a model reader, dispatcher and React connector to be passed to React components
   * in props.
   */
-case class ModelProxy[S](modelReader: ModelR[_, S], dispatch: AnyRef => Callback,
+case class ModelProxy[S](modelReader: ModelR[_, S], dispatch: Action => Callback,
   connector: ReactConnector[_ <: AnyRef]) {
   def value = modelReader()
+
 
   def apply() = modelReader()
 

--- a/examples/raf/src/main/scala/example/AppCircuit.scala
+++ b/examples/raf/src/main/scala/example/AppCircuit.scala
@@ -47,9 +47,9 @@ case class Flower(rpm: Double, position: Point = Point(1, 0), override val scale
 }
 
 // Define actions
-case object Reset
+case object Reset extends Action
 
-case class AddAnimation(animation: Animation)
+case class AddAnimation(animation: Animation) extends Action
 
 case class UpdateAnimation(id: Int) extends RAFAction
 

--- a/examples/raf/src/main/scala/example/RAFBatcher.scala
+++ b/examples/raf/src/main/scala/example/RAFBatcher.scala
@@ -4,11 +4,11 @@ import diode._
 import org.scalajs.dom._
 
 // marker trait to identify actions that should be RAF batched
-trait RAFAction
+trait RAFAction extends Action
 
-private[example] final case class RAFWrapper(action: AnyRef, dispatch: Dispatcher)
+private[example] final case class RAFWrapper(action: Action, dispatch: Dispatcher) extends Action
 
-final case class RAFTimeStamp(time: Double)
+final case class RAFTimeStamp(time: Double) extends Action
 
 class RAFBatcher[M <: AnyRef] extends ActionProcessor[M] {
   private var batch = List.empty[RAFWrapper]
@@ -29,7 +29,7 @@ class RAFBatcher[M <: AnyRef] extends ActionProcessor[M] {
         // Precede actions with a time stamp action to get correct time in animations.
         // When dispatching a sequence, Circuit optimizes processing internally and only calls
         // listeners after all the actions are processed
-        dispatch(RAFTimeStamp(time) :: actions)
+        dispatch(ActionSeq((RAFTimeStamp(time) :: actions)))
       }
       // request next frame
       requestAnimationFrame
@@ -48,7 +48,7 @@ class RAFBatcher[M <: AnyRef] extends ActionProcessor[M] {
     }
   }
 
-  override def process(dispatch: Dispatcher, action: AnyRef, next: (AnyRef) => ActionResult[M], currentModel: M) = {
+  override def process(dispatch: Dispatcher, action: Action, next: Action => ActionResult[M], currentModel: M) = {
     action match {
       case rafAction: RAFAction =>
         // save action into the batch using a wrapper

--- a/examples/simple/src/main/scala/example/AppCircuit.scala
+++ b/examples/simple/src/main/scala/example/AppCircuit.scala
@@ -6,11 +6,11 @@ import diode._
 case class RootModel(counter: Int)
 
 // Define actions
-case class Increase(amount: Int)
+case class Increase(amount: Int) extends Action
 
-case class Decrease(amount: Int)
+case class Decrease(amount: Int) extends Action
 
-case object Reset
+case object Reset extends Action
 
 /**
   * AppCircuit provides the actual instance of the `RootModel` and all the action

--- a/examples/todomvc/src/main/scala/example/AppModel.scala
+++ b/examples/todomvc/src/main/scala/example/AppModel.scala
@@ -1,4 +1,5 @@
 package example
+import diode.Action
 
 import java.util.UUID
 
@@ -29,18 +30,18 @@ object TodoFilter {
 }
 
 // define actions
-case object InitTodos
+case object InitTodos extends Action
 
-case class AddTodo(title: String)
+case class AddTodo(title: String) extends Action
 
-case class ToggleAll(checked: Boolean)
+case class ToggleAll(checked: Boolean) extends Action
 
-case class ToggleCompleted(id: TodoId)
+case class ToggleCompleted(id: TodoId) extends Action
 
-case class Update(id: TodoId, title: String)
+case class Update(id: TodoId, title: String) extends Action
 
-case class Delete(id: TodoId)
+case class Delete(id: TodoId) extends Action
 
-case class SelectFilter(filter: TodoFilter)
+case class SelectFilter(filter: TodoFilter) extends Action
 
-case object ClearCompleted
+case object ClearCompleted extends Action

--- a/examples/todomvc/src/main/scala/example/TodoList.scala
+++ b/examples/todomvc/src/main/scala/example/TodoList.scala
@@ -15,7 +15,7 @@ object TodoList {
   class Backend($: BackendScope[Props, State]) {
     def mounted(props: Props) = Callback {}
 
-    def handleNewTodoKeyDown(dispatch: AnyRef => Callback)(e: ReactKeyboardEventI): Option[Callback] = {
+    def handleNewTodoKeyDown(dispatch: diode.Action => Callback)(e: ReactKeyboardEventI): Option[Callback] = {
       val title = e.target.value.trim
       if (e.nativeEvent.keyCode == KeyCode.Enter && title.nonEmpty) {
         Some(Callback(e.target.value = "") >> dispatch(AddTodo(title)))
@@ -54,7 +54,7 @@ object TodoList {
       )
     }
 
-    def todoList(dispatch: AnyRef => Callback, editing: Option[TodoId], todos: Seq[Todo], activeCount: Int) =
+    def todoList(dispatch: diode.Action => Callback, editing: Option[TodoId], todos: Seq[Todo], activeCount: Int) =
       <.section(
         ^.className := "main",
         <.input.checkbox(
@@ -78,7 +78,7 @@ object TodoList {
         )
       )
 
-    def footer(p: Props, dispatch: AnyRef => Callback, currentFilter: TodoFilter, activeCount: Int, completedCount: Int): ReactElement =
+    def footer(p: Props, dispatch: diode.Action => Callback, currentFilter: TodoFilter, activeCount: Int, completedCount: Int): ReactElement =
       Footer(Footer.Props(
         filterLink = p.ctl.link,
         onSelectFilter = f => dispatch(SelectFilter(f)),

--- a/examples/treeview/src/main/scala/example/AppCircuit.scala
+++ b/examples/treeview/src/main/scala/example/AppCircuit.scala
@@ -28,16 +28,16 @@ case class Tree(root: Directory, selected: Seq[String])
 case class RootModel(tree: Tree)
 
 // Define actions
-case class ReplaceTree(newTree: Directory)
+case class ReplaceTree(newTree: Directory) extends Action
 
 // path is defined by a sequence of identifiers
-case class AddNode(path: Seq[String], node: FileNode)
+case class AddNode(path: Seq[String], node: FileNode) extends Action
 
-case class RemoveNode(path: Seq[String])
+case class RemoveNode(path: Seq[String]) extends Action
 
-case class ReplaceNode(path: Seq[String], node: FileNode)
+case class ReplaceNode(path: Seq[String], node: FileNode) extends Action
 
-case class Select(selected: Seq[String])
+case class Select(selected: Seq[String]) extends Action
 
 /**
   * AppCircuit provides the actual instance of the `RootModel` and all the action


### PR DESCRIPTION
The signature of Effect#toFuture has been changed from

```
def toFuture: Future[AnyRef]
```

to

```
def toFuture: Future[List[Action]]
```

to properly support EffectSet.

To migrate, simply add `extends Action` to all your case classes used as
actions.
