### PR TITLE
connect compB now passed as a component prop

### DIFF
--- a/examples/todomvc/src/main/scala/example/TodoMVC.scala
+++ b/examples/todomvc/src/main/scala/example/TodoMVC.scala
@@ -20,8 +20,10 @@ object TodoMVC extends JSApp {
   val routerConfig: RouterConfig[TodoFilter] = RouterConfigDsl[TodoFilter].buildConfig { dsl =>
     import dsl._
 
+    val todoConnection = AppCircuit.connect(_.todos)
+
     /* how the application renders the list given a filter */
-    def filterRoute(s: TodoFilter): Rule = staticRoute("#/" + s.link, s) ~> renderR(router => AppCircuit.connect(_.todos)(p => TodoList(p, s, router)))
+    def filterRoute(s: TodoFilter): Rule = staticRoute("#/" + s.link, s) ~> renderR(router => todoConnection(p => TodoList(p, s, router)))
 
     val filterRoutes: Rule = TodoFilter.values.map(filterRoute).reduce(_ | _)
 


### PR DESCRIPTION
Also updated documentation. The use case stores the component in State so that the reference to the (sub connected) component is stable during the components lifecycle. This may seem a little bit weird but it's the best solution I could come up with given the circumstances. 