### PR TITLE
Add a Pot.fromOption convenience method

### DIFF
--- a/diode-data/shared/src/main/scala/diode/data/Pot.scala
+++ b/diode-data/shared/src/main/scala/diode/data/Pot.scala
@@ -311,6 +311,11 @@ object Pot {
     */
   def empty[A]: Pot[A] = Empty
 
+  def fromOption[A](a: Option[A]) = a match {
+    case Some(x) => Ready(x)
+    case None => Empty
+  }
+
   /**
     * Monad type class for `Pot`
     */

--- a/diode-data/shared/src/test/scala/diode/data/PotTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/PotTests.scala
@@ -27,6 +27,11 @@ object PotTests extends TestSuite {
         val ps = p.ready("test").pending(50).flatMap(s => Ready(s.length))
         assert(ps.contains(4) && ps.isPending)
       }
+      'fromOption - {
+        assert(Pot.fromOption(Some("a")) == Ready("a"))
+        val none: Option[String] = None
+        assert(Pot.fromOption(none) == Empty)
+      }
     }
   }
 }


### PR DESCRIPTION
Returns `Ready` for Some's and `Empty` for None's