### PR TITLE
Pot.pending(): Do not ignore startTime arg, fixes #37.

### DIFF
--- a/diode-data/shared/src/test/scala/diode/data/PotTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/PotTests.scala
@@ -32,6 +32,20 @@ object PotTests extends TestSuite {
         val none: Option[String] = None
         assert(Pot.fromOption(none) == Empty)
       }
+      'startTime - {
+        val empty = Pot.empty[String]
+        val startTime0 = Pot.currentTime - 1L
+        val pend = empty.pending(startTime0)
+        assert( pend.asInstanceOf[PendingBase].startTime == startTime0 )
+        assert( pend.pending(startTime0).asInstanceOf[PendingBase].startTime == startTime0 )
+        assert( pend.pending().asInstanceOf[PendingBase].startTime > startTime0 )
+        val ready = pend.ready("a")
+        assert( ready.pending(startTime0).asInstanceOf[PendingBase].startTime == startTime0 )
+        assert( ready.pending().asInstanceOf[PendingBase].startTime != startTime0 )
+        val fail = ready.fail(new Exception)
+        assert( fail.pending(startTime0).asInstanceOf[PendingBase].startTime == startTime0 )
+        assert( fail.pending().asInstanceOf[PendingBase].startTime > startTime0 )
+      }
     }
   }
 }


### PR DESCRIPTION
Also, some related code deduplication: repeated calls to new
Date().getTime moved into Pot.startTimeDflt.